### PR TITLE
Allow specifying a custom cache key/cache

### DIFF
--- a/Sources/RemoteImage/private/Models/RemoteImageCache.swift
+++ b/Sources/RemoteImage/private/Models/RemoteImageCache.swift
@@ -1,0 +1,21 @@
+//
+//  RemoteImageCache.swift
+//  RemoteImage
+//
+//  Created by Wilson Gramer on 30.08.19.
+//
+
+import Foundation
+import UIKit
+
+struct RemoteImageCache: CacheRepresentable {
+    let cache = NSCache<NSString, UIImage>()
+
+    func setObject(_ obj: UIImage, forKey key: NSString) {
+        self.cache.setObject(obj, forKey: key)
+    }
+
+    func object(forKey key: NSString) -> UIImage? {
+        return self.cache.object(forKey: key)
+    }
+}

--- a/Sources/RemoteImage/public/Protocols/CacheRepresentable.swift
+++ b/Sources/RemoteImage/public/Protocols/CacheRepresentable.swift
@@ -1,0 +1,14 @@
+//
+//  CacheRepresentable.swift
+//  RemoteImage
+//
+//  Created by Wilson Gramer on 30.08.19.
+//
+
+import Foundation
+import UIKit
+
+public protocol CacheRepresentable {
+    func setObject(_ obj: UIImage, forKey key: NSString)
+    func object(forKey key: NSString) -> UIImage?
+}

--- a/Sources/RemoteImage/public/Services/RemoteImageService.swift
+++ b/Sources/RemoteImage/public/Services/RemoteImageService.swift
@@ -18,14 +18,18 @@ public final class RemoteImageService: ObservableObject {
         }
     }
     
-    public static let cache = NSCache<NSURL, UIImage>()
+    public static let cache = NSCache<NSString, UIImage>()
+    
+    public static let overrideCacheKey: (URL) -> String = { $0.absoluteString }
     
     public let objectWillChange = PassthroughSubject<Void, Never>()
     
     func fetchImage(atURL url: URL) {
         cancellable?.cancel()
         
-        if let image = RemoteImageService.cache.object(forKey: url as NSURL) {
+        let cacheKey = RemoteImageService.overrideCacheKey(url) as NSString
+        
+        if let image = RemoteImageService.cache.object(forKey: cacheKey) {
             state = .image(image)
             return
         }
@@ -44,7 +48,7 @@ public final class RemoteImageService: ObservableObject {
                 }
             }) { image in
                 if let image = image {
-                    RemoteImageService.cache.setObject(image, forKey: url as NSURL)
+                    RemoteImageService.cache.setObject(image, forKey: cacheKey)
                     self.state = .image(image)
                 } else {
                     self.state = .error(RemoteImageServiceError.couldNotCreateImage)

--- a/Sources/RemoteImage/public/Services/RemoteImageService.swift
+++ b/Sources/RemoteImage/public/Services/RemoteImageService.swift
@@ -20,7 +20,7 @@ public final class RemoteImageService: ObservableObject {
     
     public static let cache = NSCache<NSString, UIImage>()
     
-    public static let overrideCacheKey: (URL) -> String = { $0.absoluteString }
+    public static var overrideCacheKey: (URL) -> String = { $0.absoluteString }
     
     public let objectWillChange = PassthroughSubject<Void, Never>()
     

--- a/Sources/RemoteImage/public/Services/RemoteImageService.swift
+++ b/Sources/RemoteImage/public/Services/RemoteImageService.swift
@@ -18,7 +18,7 @@ public final class RemoteImageService: ObservableObject {
         }
     }
     
-    public static let cache = NSCache<NSString, UIImage>()
+    public static var cache: CacheRepresentable = RemoteImageCache()
     
     public static var overrideCacheKey: (URL) -> String = { $0.absoluteString }
     


### PR DESCRIPTION
I have a use case where I need to specify a custom key to go into the cache for a given URL. This PR allows you to override the key under which the image is saved into the cache by specifying a closure for `RemoteImageService.overrideCacheKey`, like this:

```swift
// (convoluted example) treat all images from the same domain as the same image
RemoteImageService.overrideCacheKey = { imageURL in 
    return imageURL.host!
}
```

You can also create your own cache conforming to `CacheRepresentable` and assign it to `RemoteImageService.cache` if you need greater flexibility.

Thanks for putting together this library!