### PR TITLE
Remove duplicate call to service.fetchImage in onAppear

### DIFF
--- a/Sources/RemoteImage/public/Views/RemoteImage.swift
+++ b/Sources/RemoteImage/public/Views/RemoteImage.swift
@@ -22,9 +22,6 @@ public struct RemoteImage<ErrorView: View, ImageView: View, LoadingView: View>: 
         Group {
             if service.state == .loading {
                 loadingView()
-                    .onAppear {
-                        self.service.fetchImage(ofType: self.type)
-                    }
             } else {
                 service.state.error.map { errorView($0) }
 


### PR DESCRIPTION
The double call to `service.fetchImage` was causing the following error log: `finished with error [-999] Error Domain=NSURLErrorDomain Code=-999`.